### PR TITLE
Add initial Knowledge Base post type handling

### DIFF
--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -24,7 +24,7 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 		<?php endif; ?>
 		</hgroup>
 		<hgroup class="source">
-			<time class="article-date" datetime="<?php echo get_the_date( 'c' ); ?>"><?php echo get_the_date(); ?></time>
+			Last updated <time class="article-date" datetime="<?php echo esc_attr( get_the_modified_date( 'c' ) ); ?>"><?php echo esc_html( get_the_modified_date() ); ?></time>
 			<cite class="article-author">
 				<?php
 				if ( '1' === spine_get_option( 'show_author_page' ) ) {

--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -85,6 +85,8 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 		</div>
 	<?php endif; ?>
 
+	<?php comments_template(); ?>
+
 	<footer class="article-footer">
 
 		<?php

--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -35,12 +35,6 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 				?>
 			</cite>
 		</hgroup>
-
-		<?php
-		if ( is_singular() && in_array( $post_share_placement, array( 'top', 'both' ), true ) ) {
-			get_template_part( 'parts/share-tools' );
-		}
-		?>
 	</header>
 
 	<?php if ( ! is_singular() ) : ?>
@@ -91,10 +85,6 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 
 		<?php
 
-		if ( is_singular() && in_array( $post_share_placement, array( 'bottom', 'both' ), true ) ) {
-			get_template_part( 'parts/share-tools' );
-		}
-
 		// Display site level categories attached to the post.
 		if ( has_category() ) {
 			echo '<dl class="categorized">';
@@ -103,23 +93,6 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 				echo '<dd><a href="' . esc_url( get_category_link( $category->cat_ID ) ) . '">' . esc_html( $category->cat_name ) . '</a></dd>';
 			}
 			echo '</dl>';
-		}
-
-		// Display University categories attached to the post.
-		if ( taxonomy_exists( 'wsuwp_university_category' ) && has_term( '', 'wsuwp_university_category' ) ) {
-			$university_category_terms = get_the_terms( get_the_ID(), 'wsuwp_university_category' );
-			if ( ! is_wp_error( $university_category_terms ) ) {
-				echo '<dl class="university-categorized">';
-				echo '<dt><span class="university-categorized-default">Categorized</span></dt>';
-
-				foreach ( $university_category_terms as $uc_term ) {
-					$term_link = get_term_link( $uc_term->term_id, 'wsuwp_university_category' );
-					if ( ! is_wp_error( $term_link ) ) {
-						echo '<dd><a href="' . esc_url( $term_link ) . '">' . esc_html( $uc_term->name ) . '</a></dd>';
-					}
-				}
-				echo '</dl>';
-			}
 		}
 
 		// Display University tags attached to the post.
@@ -132,55 +105,7 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 			echo '</dl>';
 		}
 
-		// Display University locations attached to the post.
-		if ( taxonomy_exists( 'wsuwp_university_location' ) && has_term( '', 'wsuwp_university_location' ) ) {
-			$university_location_terms = get_the_terms( get_the_ID(), 'wsuwp_university_location' );
-			if ( ! is_wp_error( $university_location_terms ) ) {
-				echo '<dl class="university-location">';
-				echo '<dt><span class="university-location-default">Location</span></dt>';
-
-				foreach ( $university_location_terms as $ul_term ) {
-					$term_link = get_term_link( $ul_term->term_id, 'wsuwp_university_location' );
-					if ( ! is_wp_error( $term_link ) ) {
-						echo '<dd><a href="' . esc_url( $ul_term_link ) . '">' . esc_html( $ul_term->name ) . '</a></dd>';
-					}
-				}
-				echo '</dl>';
-			}
-		}
-
-		// If a user has filled out their description and this is a multi-author blog, show a bio on their entries.
-		if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) : ?>
-		<div class="author-info">
-
-			<div class="author-avatar">
-				<?php
-				/** This filter is documented in author.php */
-				$author_bio_avatar_size = apply_filters( 'sfs411_author_bio_avatar_size', 68 );
-				echo get_avatar( get_the_author_meta( 'user_email' ), $author_bio_avatar_size );
-				?>
-			</div><!-- .author-avatar -->
-
-			<div class="author-description">
-				<h2><?php
-				/* translators: %s: author name */
-				printf( esc_html__( 'About %s', 'sfs411' ), get_the_author() );
-				?></h2>
-				<p><?php the_author_meta( 'description' ); ?></p>
-				<?php if ( '1' === spine_get_option( 'show_author_page' ) ) : ?>
-				<div class="author-link">
-					<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
-						<?php
-						/* translators: %s: author name */
-						printf( esc_html__( 'View all posts by %s', 'sfs411' ), get_the_author() );
-						?> <span class="meta-nav">&rarr;</span>
-					</a>
-				</div><!-- .author-link	-->
-				<?php endif; ?>
-			</div><!-- .author-description -->
-
-		</div><!-- .author-info -->
-	<?php endif; ?>
+		?>
 
 	</footer><!-- .entry-meta -->
 

--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Template part for displaying a Knowledge Base post's content.
+ *
+ * @package sfs411
+ */
+
+$post_share_placement = spine_get_option( 'post_social_placement' );
+
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+	<header class="article-header">
+		<hgroup>
+		<?php if ( is_single() ) : ?>
+			<?php if ( true === spine_get_option( 'articletitle_show' ) ) : ?>
+				<h1 class="article-title"><?php the_title(); ?></h1>
+			<?php endif; ?>
+		<?php else : ?>
+			<h2 class="article-title">
+				<a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a>
+			</h2>
+		<?php endif; ?>
+		</hgroup>
+		<hgroup class="source">
+			<time class="article-date" datetime="<?php echo get_the_date( 'c' ); ?>"><?php echo get_the_date(); ?></time>
+			<cite class="article-author">
+				<?php
+				if ( '1' === spine_get_option( 'show_author_page' ) ) {
+					the_author_posts_link();
+				} else {
+					echo esc_html( get_the_author() );
+				}
+				?>
+			</cite>
+		</hgroup>
+
+		<?php
+		if ( is_singular() && in_array( $post_share_placement, array( 'top', 'both' ), true ) ) {
+			get_template_part( 'parts/share-tools' );
+		}
+		?>
+	</header>
+
+	<?php if ( ! is_singular() ) : ?>
+		<div class="article-summary">
+			<?php
+
+			if ( spine_has_thumbnail_image() ) {
+				?><figure class="article-thumbnail"><a href="<?php the_permalink(); ?>"><?php spine_the_thumbnail_image(); ?></a></figure><?php
+			} elseif ( spine_has_featured_image() ) {
+				?><figure class="article-thumbnail"><a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'spine-thumbnail_size' ); ?></a></figure><?php
+			}
+
+			// If a manual excerpt is available, default to that. If `<!--more-->` exists in content, default
+			// to that. If an option is set specifically to display excerpts, default to that. Otherwise show
+			// full content.
+			if ( $post->post_excerpt ) {
+				echo wp_kses_post( get_the_excerpt() ) . ' <a href="' . esc_url( get_permalink() ) . '"><span class="excerpt-more-default">&raquo; More ...</span></a>';
+			} elseif ( strstr( $post->post_content, '<!--more-->' ) ) {
+				the_content( '<span class="content-more-default">&raquo; More ...</span>' );
+			} elseif ( 'excerpt' === spine_get_option( 'archive_content_display' ) ) {
+				the_excerpt();
+			} else {
+				the_content();
+			}
+
+			?>
+		</div><!-- .article-summary -->
+	<?php else : ?>
+		<div class="article-body">
+			<?php
+
+			the_content();
+
+			wp_link_pages(
+				array(
+					'before' => '<div class="page-links">' . __( 'Pages:', 'spine' ),
+					'after' => '</div>',
+				)
+			);
+
+			?>
+		</div>
+	<?php endif; ?>
+
+	<footer class="article-footer">
+
+		<?php
+
+		if ( is_singular() && in_array( $post_share_placement, array( 'bottom', 'both' ), true ) ) {
+			get_template_part( 'parts/share-tools' );
+		}
+
+		// Display site level categories attached to the post.
+		if ( has_category() ) {
+			echo '<dl class="categorized">';
+			echo '<dt><span class="categorized-default">Categorized</span></dt>';
+			foreach ( get_the_category() as $category ) {
+				echo '<dd><a href="' . esc_url( get_category_link( $category->cat_ID ) ) . '">' . esc_html( $category->cat_name ) . '</a></dd>';
+			}
+			echo '</dl>';
+		}
+
+		// Display University categories attached to the post.
+		if ( taxonomy_exists( 'wsuwp_university_category' ) && has_term( '', 'wsuwp_university_category' ) ) {
+			$university_category_terms = get_the_terms( get_the_ID(), 'wsuwp_university_category' );
+			if ( ! is_wp_error( $university_category_terms ) ) {
+				echo '<dl class="university-categorized">';
+				echo '<dt><span class="university-categorized-default">Categorized</span></dt>';
+
+				foreach ( $university_category_terms as $uc_term ) {
+					$term_link = get_term_link( $uc_term->term_id, 'wsuwp_university_category' );
+					if ( ! is_wp_error( $term_link ) ) {
+						echo '<dd><a href="' . esc_url( $term_link ) . '">' . esc_html( $uc_term->name ) . '</a></dd>';
+					}
+				}
+				echo '</dl>';
+			}
+		}
+
+		// Display University tags attached to the post.
+		if ( has_tag() ) {
+			echo '<dl class="tagged">';
+			echo '<dt><span class="tagged-default">Tagged</span></dt>';
+			foreach ( get_the_tags() as $post_tag ) {
+				echo '<dd><a href="' . esc_url( get_tag_link( $post_tag->term_id ) ) . '">' . esc_html( $post_tag->name ) . '</a></dd>';
+			}
+			echo '</dl>';
+		}
+
+		// Display University locations attached to the post.
+		if ( taxonomy_exists( 'wsuwp_university_location' ) && has_term( '', 'wsuwp_university_location' ) ) {
+			$university_location_terms = get_the_terms( get_the_ID(), 'wsuwp_university_location' );
+			if ( ! is_wp_error( $university_location_terms ) ) {
+				echo '<dl class="university-location">';
+				echo '<dt><span class="university-location-default">Location</span></dt>';
+
+				foreach ( $university_location_terms as $ul_term ) {
+					$term_link = get_term_link( $ul_term->term_id, 'wsuwp_university_location' );
+					if ( ! is_wp_error( $term_link ) ) {
+						echo '<dd><a href="' . esc_url( $ul_term_link ) . '">' . esc_html( $ul_term->name ) . '</a></dd>';
+					}
+				}
+				echo '</dl>';
+			}
+		}
+
+		// If a user has filled out their description and this is a multi-author blog, show a bio on their entries.
+		if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) : ?>
+		<div class="author-info">
+
+			<div class="author-avatar">
+				<?php
+				/** This filter is documented in author.php */
+				$author_bio_avatar_size = apply_filters( 'sfs411_author_bio_avatar_size', 68 );
+				echo get_avatar( get_the_author_meta( 'user_email' ), $author_bio_avatar_size );
+				?>
+			</div><!-- .author-avatar -->
+
+			<div class="author-description">
+				<h2><?php
+				/* translators: %s: author name */
+				printf( esc_html__( 'About %s', 'sfs411' ), get_the_author() );
+				?></h2>
+				<p><?php the_author_meta( 'description' ); ?></p>
+				<?php if ( '1' === spine_get_option( 'show_author_page' ) ) : ?>
+				<div class="author-link">
+					<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+						<?php
+						/* translators: %s: author name */
+						printf( esc_html__( 'View all posts by %s', 'sfs411' ), get_the_author() );
+						?> <span class="meta-nav">&rarr;</span>
+					</a>
+				</div><!-- .author-link	-->
+				<?php endif; ?>
+			</div><!-- .author-description -->
+
+		</div><!-- .author-info -->
+	<?php endif; ?>
+
+	</footer><!-- .entry-meta -->
+
+</article>

--- a/comments.php
+++ b/comments.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * The template file for displaying the comments and comment form.
+ *
+ * Copied from the Twenty Twenty theme.
+ *
+ * @package sfs411
+ */
+
+/*
+ * If the current post is protected by a password and
+ * the visitor has not yet entered the password we will
+ * return early without loading the comments.
+*/
+if ( post_password_required() ) {
+	return;
+}
+
+if ( $comments ) {
+	$comments_number = absint( get_comments_number() );
+	?>
+
+	<div class="comments" id="comments">
+
+		<div class="comments-header">
+
+			<h2 class="comment-reply-title">
+			<?php
+			if ( ! have_comments() ) {
+				esc_html_e( 'Leave a comment', 'sfs411' );
+			} elseif ( '1' === $comments_number ) {
+				/* translators: %s: post title */
+				printf( esc_html_x( 'One reply on &ldquo;%s&rdquo;', 'comments title', 'sfs411' ), esc_html( get_the_title() ) );
+			} else {
+				echo esc_html(
+					sprintf(
+						/* translators: 1: number of comments, 2: post title */
+						_nx(
+							'%1$s reply on &ldquo;%2$s&rdquo;',
+							'%1$s replies on &ldquo;%2$s&rdquo;',
+							$comments_number,
+							'comments title',
+							'sfs411'
+						),
+						esc_html( number_format_i18n( $comments_number ) ),
+						esc_html( get_the_title() )
+					)
+				);
+			}
+
+			?>
+			</h2><!-- .comments-title -->
+
+		</div><!-- .comments-header -->
+
+		<div class="comments-inner section-inner thin max-percentage">
+
+			<?php
+			wp_list_comments(
+				array(
+					'avatar_size' => 0,
+					'style'       => 'div',
+					'format'      => 'html5',
+					'page'        => get_the_ID(),
+				)
+			);
+
+			$comment_pagination = paginate_comments_links(
+				array(
+					'echo'      => false,
+					'end_size'  => 0,
+					'mid_size'  => 0,
+					'next_text' => __( 'Newer Comments', 'sfs411' ) . ' <span aria-hidden="true">&rarr;</span>',
+					'prev_text' => '<span aria-hidden="true">&larr;</span> ' . __( 'Older Comments', 'sfs411' ),
+				)
+			);
+
+			if ( $comment_pagination ) {
+				$pagination_classes = '';
+
+				// If we're only showing the "Next" link, add a class indicating so.
+				if ( false === strpos( $comment_pagination, 'prev page-numbers' ) ) {
+					$pagination_classes = ' only-next';
+				}
+				?>
+
+				<nav class="comments-pagination pagination<?php echo $pagination_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>" aria-label="<?php esc_attr_e( 'Comments', 'sfs411' ); ?>">
+					<?php echo wp_kses_post( $comment_pagination ); ?>
+				</nav>
+
+				<?php
+			}
+			?>
+
+		</div><!-- .comments-inner -->
+
+	</div><!-- comments -->
+
+	<?php
+}
+
+if ( comments_open() ) {
+
+	comment_form(
+		array(
+			'format' => 'html5',
+		)
+	);
+
+} elseif ( is_single() ) {
+
+	?>
+
+	<div class="comment-respond" id="respond">
+
+		<p class="comments-closed"><?php esc_html_e( 'Comments are closed.', 'sfs411' ); ?></p>
+
+	</div><!-- #respond -->
+
+	<?php
+}

--- a/css/knowledge-base.css
+++ b/css/knowledge-base.css
@@ -1,0 +1,3 @@
+article.type-knowledge_base header time:before {
+	content: none;
+}

--- a/functions.php
+++ b/functions.php
@@ -6,3 +6,5 @@
  *
  * @package sfs411
  */
+
+require_once 'includes/knowledge-base-post-type.php';

--- a/includes/knowledge-base-post-type.php
+++ b/includes/knowledge-base-post-type.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Handling for the Knowledge Base post type.
+ *
+ * @package sfs411
+ */
+
+namespace SFS411\Post_Type\Knowledge_Base;
+
+add_action( 'init', __NAMESPACE__ . '\register_post_type' );
+
+/**
+ * Register the Knowledge Base post type.
+ */
+function register_post_type() {
+
+	$args = array(
+		'label'                  => __( 'Knowledge Base', 'sfs411' ),
+		'labels'                 => array(
+			'name'               => _x( 'Knowledge Base', 'Post Type General Name', 'sfs411' ),
+			'singular_name'      => _x( 'Knowledge Base', 'Post Type Singular Name', 'pfmc-feature-set' ),
+		),
+		'description'           => '',
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'show_ui'               => true,
+		'delete_with_user'      => false,
+		'has_archive'           => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => false,
+		'exclude_from_search'   => false,
+		'capability_type'       => 'post',
+		'map_meta_cap'          => true,
+		'hierarchical'          => false,
+		'query_var'             => true,
+		'menu_position'         => 5,
+		'menu_icon'             => 'dashicons-clipboard',
+		'show_in_rest'          => true,
+		'rewrite'               => array(
+			'slug'       => __( 'knowledge-base', 'sfs411' ),
+			'with_front' => false,
+		),
+		'supports'              => array(
+			'title',
+			'editor',
+			'author',
+			'comments',
+			'revisions',
+		),
+		'taxonomies'            => array(
+			'category',
+			'post_tag',
+		),
+	);
+
+	\register_post_type( 'knowledge_base', $args );
+}

--- a/single-knowledge_base.php
+++ b/single-knowledge_base.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Template for displaying a Knowledge Base post's layout.
+ *
+ * @package sfs411
+ */
+
+get_header();
+
+do_action( 'spine_theme_template_before_main', 'single-knowledge-base.php' );
+
+?>
+
+<main id="wsuwp-main">
+
+	<?php
+
+	do_action( 'spine_theme_template_before_headers', 'single-knowledge-base.php' );
+
+	wsuwp_spine_get_template_part( 'single-knowledge-base.php', 'parts/headers' );
+
+	do_action( 'spine_theme_template_after_headers', 'single-knowledge-base.php' );
+
+	do_action( 'spine_theme_template_before_content', 'single-knowledge-base.php' );
+
+	if ( spine_has_featured_image() && 'page' !== get_post_type() ) {
+		$featured_image_src = spine_get_featured_image_src();
+		$featured_image_position = get_post_meta( get_the_ID(), '_featured_image_position', true );
+
+		if ( ! $featured_image_position || sanitize_html_class( $featured_image_position ) !== $featured_image_position ) {
+			$featured_image_position = '';
+		}
+		?><figure class="featured-image <?php echo sanitize_html_class( $featured_image_position ); ?>" style="background-image: url('<?php echo esc_url( $featured_image_src ); ?>');"><?php spine_the_featured_image(); ?></figure><?php
+	}
+
+	?>
+
+	<section class="row side-right gutter pad-ends">
+
+		<div class="column one">
+
+			<?php while ( have_posts() ) : the_post(); ?>
+
+				<?php get_template_part( 'articles/post', get_post_type() ) ?>
+
+			<?php endwhile; ?>
+
+		</div><!--/column-->
+
+		<div class="column two"></div><!--/column two-->
+
+	</section>
+
+	<footer class="main-footer">
+		<section class="row halves pager prevnext gutter pad-ends">
+			<div class="column one">
+				<?php previous_post_link(); ?>
+			</div>
+			<div class="column two">
+				<?php next_post_link(); ?>
+			</div>
+		</section><!--pager-->
+	</footer>
+
+	<?php
+
+	do_action( 'spine_theme_template_after_content', 'single-knowledge-base.php' );
+
+	do_action( 'spine_theme_template_before_footer', 'single-knowledge-base.php' );
+
+	wsuwp_spine_get_template_part( 'single-knowledge-base.php', 'parts/footers' );
+
+	do_action( 'spine_theme_template_after_footer', 'single-knowledge-base.php' );
+
+	?>
+
+</main><!--/#page-->
+
+<?php
+
+do_action( 'spine_theme_template_after_main', 'single-knowledge-base.php' );
+
+get_footer();

--- a/style.css
+++ b/style.css
@@ -7,4 +7,8 @@
  Template:       spine
  Version:        0.0.1
 */
+
+article.type-knowledge_base header time:before {
+	content: none;
+}
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
* Registers the `knowledge_base` post type.
* Introduces template files for `knowledge_base` posts.
  * These can likely be stripped down quite a bit more.
* Introduces a `comments.php` template.
* Adds one CSS rule for specifically for Knowledge Base posts.
  * This can be incorporated into a properly named stylesheet later.