### PR TITLE
Add initial handling for content flagging feature

### DIFF
--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -85,7 +85,12 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 		</div>
 	<?php endif; ?>
 
-	<?php comments_template(); ?>
+	<?php
+	// Display the comments template if the current user is logged in.
+	//if ( is_user_logged_in() ) {
+		comments_template();
+	//}
+	?>
 
 	<footer class="article-footer">
 

--- a/comments.php
+++ b/comments.php
@@ -83,7 +83,7 @@ if ( $comments ) {
 				}
 				?>
 
-				<nav class="comments-pagination pagination<?php echo $pagination_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>" aria-label="<?php esc_attr_e( 'Comments', 'sfs411' ); ?>">
+				<nav class="comments-pagination pagination<?php echo esc_attr( $pagination_classes ); ?>" aria-label="<?php esc_attr_e( 'Comments', 'sfs411' ); ?>">
 					<?php echo wp_kses_post( $comment_pagination ); ?>
 				</nav>
 

--- a/comments.php
+++ b/comments.php
@@ -60,7 +60,6 @@ if ( $comments ) {
 				array(
 					'avatar_size' => 0,
 					'style'       => 'div',
-					'format'      => 'html5',
 					'page'        => get_the_ID(),
 				)
 			);
@@ -101,11 +100,7 @@ if ( $comments ) {
 
 if ( comments_open() ) {
 
-	comment_form(
-		array(
-			'format' => 'html5',
-		)
-	);
+	comment_form();
 
 } elseif ( is_single() ) {
 

--- a/functions.php
+++ b/functions.php
@@ -9,3 +9,4 @@
 
 require_once 'includes/knowledge-base-post-type.php';
 require_once 'includes/comment-form.php';
+require_once 'includes/flagged-posts.php';

--- a/functions.php
+++ b/functions.php
@@ -8,3 +8,4 @@
  */
 
 require_once 'includes/knowledge-base-post-type.php';
+require_once 'includes/comment-form.php';

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -10,6 +10,7 @@ namespace SFS411\Comment\Form;
 add_action( 'after_setup_theme', __NAMESPACE__ . '\register_html5_support' );
 add_filter( 'comment_form_fields', __NAMESPACE__ . '\filter_comment_form_fields', 10 );
 add_filter( 'preprocess_comment', __NAMESPACE__ . '\preprocess_comment_data', 10 );
+
 /**
  * Registers HTML5 support for the comment form and comments output.
  */

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -29,11 +29,13 @@ function register_html5_support() {
  * @return array $comment_fields A modified list of comment fields.
  */
 function filter_comment_form_fields( $comment_fields ) {
+	if ( 'knowledge_base' === get_post_type() ) {
 
-	// Add a checkbox for flagging that the comment is about bad content on the post.
-	$flag_checkbox = '<p class="comment-form-flag"><input type="checkbox" id="content-flag" name="content_flag" /><label for="content-flag">This post has old, missing, or incorrect content</label></p>';
+		// Add a checkbox for flagging that the comment is about bad content on the post.
+		$flag_checkbox = '<p class="comment-form-flag"><input type="checkbox" id="content-flag" name="content_flag" /><label for="content-flag">This post has old, missing, or incorrect content</label></p>';
 
-	$comment_fields['comment'] = $comment_fields['comment'] . $flag_checkbox;
+		$comment_fields['comment'] = $comment_fields['comment'] . $flag_checkbox;
+	}
 
 	return $comment_fields;
 }

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -8,7 +8,8 @@
 namespace SFS411\Comment\Form;
 
 add_action( 'after_setup_theme', __NAMESPACE__ . '\register_html5_support' );
-
+add_filter( 'comment_form_fields', __NAMESPACE__ . '\filter_comment_form_fields', 10 );
+add_filter( 'preprocess_comment', __NAMESPACE__ . '\preprocess_comment_data', 10 );
 /**
  * Registers HTML5 support for the comment form and comments output.
  */
@@ -17,4 +18,36 @@ function register_html5_support() {
 		'comment-form',
 		'comment-list',
 	) );
+}
+
+/**
+ * Add a checkbox to the comment form for flagging posts with bad content.
+ *
+ * @param array $comment_fields A list of comment fields to output when capturing a comment.
+ * @return array $comment_fields A modified list of comment fields.
+ */
+function filter_comment_form_fields( $comment_fields ) {
+
+	// Add a checkbox for flagging that the comment is about bad content on the post.
+	$flag_checkbox = '<p class="comment-form-flag"><input type="checkbox" id="content-flag" name="content_flag" /><label for="content-flag">This post has old, missing, or incorrect content</label></p>';
+
+	$comment_fields['comment'] = $comment_fields['comment'] . $flag_checkbox;
+
+	return $comment_fields;
+}
+
+/**
+ * If the comment is about bad content, save it as a `flagged_content` type.
+ *
+ * @param array $commentdata Submitted comment data.
+ * @return array $commentdata Modified comment data.
+ */
+function preprocess_comment_data( $commentdata ) {
+
+	// Nonce verification is not necessary for the comment form.
+	if ( is_user_logged_in() && isset( $_POST['content_flag'] ) ) { // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+		$commentdata['comment_type'] = 'flagged_content';
+	}
+
+	return $commentdata;
 }

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Handling for customizations to the comment form.
+ *
+ * @package sfs411
+ */
+
+namespace SFS411\Comment\Form;
+
+add_action( 'after_setup_theme', __NAMESPACE__ . '\register_html5_support' );
+
+/**
+ * Registers HTML5 support for the comment form and comments output.
+ */
+function register_html5_support() {
+	add_theme_support( 'html5', array(
+		'comment-form',
+		'comment-list',
+	) );
+}

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -10,6 +10,7 @@ namespace SFS411\Comment\Form;
 add_action( 'after_setup_theme', __NAMESPACE__ . '\register_html5_support' );
 add_filter( 'comment_form_fields', __NAMESPACE__ . '\filter_comment_form_fields', 10 );
 add_filter( 'preprocess_comment', __NAMESPACE__ . '\preprocess_comment_data', 10 );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_comment_reply_script' );
 
 /**
  * Registers HTML5 support for the comment form and comments output.
@@ -51,4 +52,13 @@ function preprocess_comment_data( $commentdata ) {
 	}
 
 	return $commentdata;
+}
+
+/**
+ * Enqueues the comment reply script if appropriate.
+ */
+function enqueue_comment_reply_script() {
+	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+		wp_enqueue_script( 'comment-reply' );
+	}
 }

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -110,12 +110,12 @@ function comment_row_actions( $actions, $comment ) {
 
 	// Return early if this is not the Flagged Posts page.
 	if ( ! is_flagged_posts_page() ) {
-		return;
+		return $actions;
 	}
 
 	// Return early if the comment is not of the `flagged_content` type.
 	if ( 'flagged_content' !== $comment->comment_type ) {
-		return;
+		return $actions;
 	}
 
 	// Unset `unapprove` and`approve` actions, not applicable in this case.

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -121,9 +121,10 @@ function comment_row_actions( $actions, $comment ) {
 		return $actions;
 	}
 
-	// Unset `unapprove` and`approve` actions, not applicable in this case.
+	// Unset `unapprove`, `approve`, and `spam` actions.
 	unset( $actions['unapprove'] );
 	unset( $actions['approve'] );
+	unset( $actions['spam'] );
 
 	// Modify the default `reply` action to use as a "Resolve" button.
 	$actions['reply'] = sprintf(
@@ -264,7 +265,7 @@ function filter_comment_counts( $count, $post_id ) {
 /**
  * Modifies the status links for the Flagged Posts page.
  *
- * This removes the "Pending" and "Approved" links,
+ * This removes the "Pending", "Approved", and "Spam" links,
  * and fixes the count for the "Mine" link, since that doesn't
  * seem possible to do through the `wp_count_comments` filter.
  *
@@ -280,6 +281,7 @@ function flagged_posts_status_links( $status_links ) {
 
 	unset( $status_links['moderated'] );
 	unset( $status_links['approved'] );
+	unset( $status_links['spam'] );
 
 	$comments_query = new \WP_Comment_Query();
 

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -180,7 +180,8 @@ function admin_footer() {
 }
 
 /**
- * If the comment is about bad content, save it as a `flagged_content` type.
+ * If a comment reply is marked as a resolution for a bad content flag,
+ * update the parent comment type to `resolved`.
  *
  * @param array $commentdata Submitted comment data.
  * @return array $commentdata Modified comment data.

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Handling for the Flagged Posts dashboard.
+ *
+ * @package sfs411
+ */
+
+namespace SFS411\Dashboard\Flagged_Content;
+
+add_action( 'admin_menu', __NAMESPACE__ . '\add_flagged_posts_page' );
+add_filter( 'parent_file', __NAMESPACE__ . '\flagged_posts_parent_file' );
+add_filter( 'submenu_file', __NAMESPACE__ . '\flagged_posts_submenu_file' );
+add_action( 'adminmenu', __NAMESPACE__ . '\adminmenu' );
+
+/**
+ * Adds the Flagged Posts page the the Knowledge Base menu.
+ */
+function add_flagged_posts_page() {
+	add_submenu_page(
+		'edit.php?post_type=knowledge_base',
+		'Flagged Posts',
+		'Flagged Posts',
+		'manage_options',
+		'edit-comments.php?comment_type=flagged_content&post_type=knowledge_base',
+		'',
+		1
+	);
+}
+
+/**
+ * Determines if the current page is the Flagged Posts page.
+ */
+function is_flagged_posts_page() {
+	if ( ! isset( $_GET['comment_type'] ) || 'flagged_content' !== $_GET['comment_type'] ) { // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Filters the parent file of the Flagged Posts menu item.
+ *
+ * @param string $parent_file The parent file.
+ * @return string The parent file.
+ */
+function flagged_posts_parent_file( $parent_file ) {
+	if ( is_flagged_posts_page() ) {
+		$parent_file = 'edit.php?post_type=knowledge_base';
+	}
+
+	return $parent_file;
+}
+
+/**
+ * Filters the file of the Flagged Posts menu item.
+ *
+ * @param string $submenu_file The submenu file.
+ * @return string The submenu file.
+ */
+function flagged_posts_submenu_file( $submenu_file ) {
+	if ( is_flagged_posts_page() ) {
+		$submenu_file = 'edit-comments.php?comment_type=flagged_content&post_type=knowledge_base';
+	}
+
+	return $submenu_file;
+}
+
+/**
+ * Removes the `current` classes and aria attributes from the Comments menu
+ * item when Flagged Posts is the current page.
+ *
+ * Filtering the parent and submenu file doesn't take care of this,
+ * because the Flagged Posts page technically is the Comments page,
+ * presumably.
+ */
+function adminmenu() {
+	if ( ! is_flagged_posts_page() ) {
+		return;
+	}
+	?>
+	<script type="text/javascript">
+		function commentsMenuItem() {
+			const item = document.getElementById( 'menu-comments' );
+			const link = item.querySelector( 'a' );
+
+			item.classList.remove( 'current' );
+			link.classList.remove( 'current' );
+			link.removeAttribute( 'aria-current' );
+		};
+
+		commentsMenuItem();
+	</script>
+	<?php
+}

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -166,7 +166,14 @@ function admin_footer() {
 			replyContainer.appendChild( label );
 		};
 
+		function removeFilterActions() {
+			const filterActions = document.getElementById( 'filter-by-comment-type' ).parentNode;
+
+			filterActions.parentNode.removeChild( filterActions );
+		}
+
 		addResolveCheckbox();
+		removeFilterActions();
 	</script>
 	<?php
 }

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -17,6 +17,7 @@ add_filter( 'preprocess_comment', __NAMESPACE__ . '\preprocess_comment_data' );
 add_action( 'pre_get_comments', __NAMESPACE__ . '\filter_comments_query' );
 add_filter( 'wp_count_comments', __NAMESPACE__ . '\filter_comment_counts', 10, 2 );
 add_filter( 'comment_status_links', __NAMESPACE__ . '\flagged_posts_status_links' );
+add_filter( 'bulk_actions-edit-comments', __NAMESPACE__ . '\filter_bulk_actions' );
 
 /**
  * Adds the Flagged Posts page the the Knowledge Base menu.
@@ -313,4 +314,25 @@ function flagged_posts_status_links( $status_links ) {
 	);
 
 	return $status_links;
+}
+
+/**
+ * Filters the bulk actions available on the Flagged Posts page.
+ *
+ * @param array $actions Array of default bulk actions.
+ * @return array Modified array of bulk actions.
+ */
+function filter_bulk_actions( $actions ) {
+
+	// Return early if this is not the Flagged Posts page.
+	if ( ! is_flagged_posts_page() ) {
+		return $actions;
+	}
+
+	// Remove the `unapprove`, `approve`, and `spam` bulk actions.
+	unset( $actions['unapprove'] );
+	unset( $actions['approve'] );
+	unset( $actions['spam'] );
+
+	return $actions;
 }

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -78,6 +78,8 @@ function flagged_posts_submenu_file( $submenu_file ) {
  * presumably.
  */
 function adminmenu() {
+
+	// Return early if this is not the Flagged Posts page.
 	if ( ! is_flagged_posts_page() ) {
 		return;
 	}
@@ -99,23 +101,28 @@ function adminmenu() {
 
 /**
  * Removes the `unapprove` and `approve` row actions and repurposes `reply`
- * into a `resolve` action.
+ * for use as part of the resolution workflow.
  *
  * @param array      $actions Array of comment actions.
  * @param WP_Comment $comment The comment object.
  */
 function comment_row_actions( $actions, $comment ) {
+
+	// Return early if this is not the Flagged Posts page.
 	if ( ! is_flagged_posts_page() ) {
 		return;
 	}
 
+	// Return early if the comment is not of the `flagged_content` type.
 	if ( 'flagged_content' !== $comment->comment_type ) {
 		return;
 	}
 
+	// Unset `unapprove` and`approve` actions, not applicable in this case.
 	unset( $actions['unapprove'] );
 	unset( $actions['approve'] );
 
+	// Modify the default `reply` action to use as a "Resolve" button.
 	$actions['reply'] = sprintf(
 		'<button type="button" onclick="window.commentReply && commentReply.open(\'%s\',\'%s\');" class="vim-r button-link hide-if-no-js" aria-label="%s">%s</button>',
 		$comment->comment_ID,
@@ -131,6 +138,8 @@ function comment_row_actions( $actions, $comment ) {
  * Add a checkbox to the comment list table reply form for resolving flags.
  */
 function admin_footer() {
+
+	// Return early if this is not the Flagged Posts page.
 	if ( ! is_flagged_posts_page() ) {
 		return;
 	}
@@ -168,7 +177,6 @@ function preprocess_comment_data( $commentdata ) {
 
 	// Nonce verification is not necessary for the comment form.
 	if ( is_user_logged_in() && isset( $_POST['resolve_flag'] ) && isset( $commentdata['comment_parent'] ) ) { // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
-
 		wp_update_comment( array(
 			'comment_ID'   => $commentdata['comment_parent'],
 			'comment_type' => 'resolved',

--- a/includes/knowledge-base-post-type.php
+++ b/includes/knowledge-base-post-type.php
@@ -19,6 +19,7 @@ function register_post_type() {
 		'labels'                 => array(
 			'name'               => _x( 'Knowledge Base', 'Post Type General Name', 'sfs411' ),
 			'singular_name'      => _x( 'Knowledge Base', 'Post Type Singular Name', 'pfmc-feature-set' ),
+			'all_items'          => __( 'All Posts', 'sfs411' ),
 		),
 		'description'           => '',
 		'public'                => true,


### PR DESCRIPTION
- Introduce support for flagging when a comment is about bad content.
- Add a "Flagged Posts" dashboard page that repurposes the comments list table.
- Remove the `Unapprove` and `Approve` comment row actions.
- Renames the `Reply` row action as `Resolve`.
- Add a checkbox for resolving a flagged comment to the inline `Reply` form, checked by default.
- Enqueue the comment reply script if appropriate.

This assumes that:
- the Knowledge Base post type needs to support regular comments as well as comments for flagging bad content;
- the comment form on Knowledge Base posts should display only for authorized users, regardless of Discussion settings;
- the approval process is not applicable to comments on Knowledge Base posts;
- a note should be captured whenever a comment about bad content is marked as resolved;
- there may be cases where a reply to a comment about bad content is not meant to resolve the concern (in which case the user could uncheck the box);
- spam will not be an issue for comments on Knowledge Base posts (possibly a false assumption);
- "Comments" is an okay heading for the "Flagged Posts" dashboard page :).

This should be rebased against master after https://github.com/happyprime/wsu-sfs411/pull/2 is merged.