### PR TITLE
Add initial handling for stale content dashboard

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -10,3 +10,4 @@
 require_once 'includes/knowledge-base-post-type.php';
 require_once 'includes/comment-form.php';
 require_once 'includes/flagged-posts.php';
+require_once 'includes/stale-posts.php';

--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,19 @@
  * @package sfs411
  */
 
+add_filter( 'spine_child_theme_version', 'sfs411_theme_version' );
+
+/**
+ * Provides a theme version for use in cache busting.
+ *
+ * @since 0.0.1
+ *
+ * @return string
+ */
+function sfs411_theme_version() {
+	return '0.0.1';
+}
+
 require_once 'includes/knowledge-base-post-type.php';
 require_once 'includes/comment-form.php';
 require_once 'includes/flagged-posts.php';

--- a/includes/css/stale-content-meta-box.css
+++ b/includes/css/stale-content-meta-box.css
@@ -1,0 +1,3 @@
+#sfs411-staleness-management_options-note {
+	width: 100%;
+}

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -27,7 +27,7 @@ function add_flagged_posts_page() {
 		'edit.php?post_type=knowledge_base',
 		'Flagged Posts',
 		'Flagged Posts',
-		'manage_options',
+		'moderate_comments',
 		'edit-comments.php?comment_type=flagged_content',
 		'',
 		1

--- a/includes/js/stale-content-meta-box.js
+++ b/includes/js/stale-content-meta-box.js
@@ -1,0 +1,30 @@
+const stalenessMetaBoxHandling = ( function() {
+	const resetButton              = document.getElementById( 'sfs411-staleness-settings_reset' );
+	const durationOptionsContainer = document.getElementById( 'sfs411-staleness-settings_duration-options' );
+	const durationOptions          = Array.prototype.slice.apply( durationOptionsContainer.querySelectorAll( 'input' ) );
+
+	/**
+	 * Toggles the display and `disabled` attributes of the duration options.
+	 *
+	 * @param {object} event The click event.
+	 */
+	function resetStaleness( event ) {
+		if ( event.target.classList.contains( 'cancel' ) ) {
+			durationOptionsContainer.classList.add( 'hidden' );
+			resetButton.classList.remove( 'cancel' );
+			resetButton.innerText = 'Reset';
+			durationOptions.forEach( ( option ) => {
+				option.setAttribute( 'disabled', '' );
+			} );
+		} else {
+			durationOptionsContainer.classList.remove( 'hidden' );
+			resetButton.classList.add( 'cancel' );
+			resetButton.innerText = 'Cancel';
+			durationOptions.forEach( ( option ) => {
+				option.removeAttribute( 'disabled' );
+			} );
+		}
+	}
+
+	resetButton.addEventListener( 'click', resetStaleness );
+} () );

--- a/includes/js/stale-content-meta-box.js
+++ b/includes/js/stale-content-meta-box.js
@@ -1,7 +1,8 @@
 const stalenessMetaBoxHandling = ( function() {
-	const resetButton              = document.getElementById( 'sfs411-staleness-settings_reset' );
-	const durationOptionsContainer = document.getElementById( 'sfs411-staleness-settings_duration-options' );
+	const durationOptionsContainer = document.getElementById( 'sfs411-staleness-management_options' );
 	const durationOptions          = Array.prototype.slice.apply( durationOptionsContainer.querySelectorAll( 'input' ) );
+	const resetNote                = document.getElementById( 'sfs411-staleness-management_options-note' );
+	const resetButton              = document.getElementById( 'sfs411-staleness-management_reset' );
 
 	/**
 	 * Toggles the display and `disabled` attributes of the duration options.
@@ -10,19 +11,25 @@ const stalenessMetaBoxHandling = ( function() {
 	 */
 	function resetStaleness( event ) {
 		if ( event.target.classList.contains( 'cancel' ) ) {
-			durationOptionsContainer.classList.add( 'hidden' );
 			resetButton.classList.remove( 'cancel' );
 			resetButton.innerText = 'Reset';
+
+			durationOptionsContainer.classList.add( 'hidden' );
 			durationOptions.forEach( ( option ) => {
 				option.setAttribute( 'disabled', '' );
 			} );
+
+			resetNote.setAttribute( 'disabled', '' );
 		} else {
-			durationOptionsContainer.classList.remove( 'hidden' );
 			resetButton.classList.add( 'cancel' );
 			resetButton.innerText = 'Cancel';
+
+			durationOptionsContainer.classList.remove( 'hidden' );
 			durationOptions.forEach( ( option ) => {
 				option.removeAttribute( 'disabled' );
 			} );
+
+			resetNote.removeAttribute( 'disabled' );
 		}
 	}
 

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -73,8 +73,6 @@ function get_stale_in_fields() {
 /**
  * Displays a meta box used to manage post staleness.
  *
- * @since 0.3.0
- *
  * @param \WP_Post $post
  */
 function display_staleness_management_meta_box( $post ) {
@@ -166,8 +164,6 @@ function enqueue_meta_box_assets( $hook_suffix ) {
 
 /**
  * Saves the meta for tracking the staleness of a post.
- *
- * @since 0.3.0
  *
  * @param int      $post_id
  * @param \WP_Post $post

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -340,15 +340,14 @@ function filter_by_stale_posts( $query ) {
 		return;
 	}
 
-	$query->set(
-		'meta_query',
+	$query->set( 'post_status', 'publish' );
+
+	$query->set( 'meta_query', array(
 		array(
-			array(
-				'key'     => '_sfs411_stale_by',
-				'value'   => date( 'Y-m-d' ),
-				'compare' => '<=',
-				'type'    => 'DATE',
-			),
-		)
-	);
+			'key'     => '_sfs411_stale_by',
+			'value'   => date( 'Y-m-d' ),
+			'compare' => '<=',
+			'type'    => 'DATE',
+		),
+	) );
 }

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -45,10 +45,6 @@ function stale_posts_submenu_file( $submenu_file ) {
 
 /**
  * Adds a meta box for managing post staleness.
- *
- * @since 0.3.0
- *
- * @param string $post_type
  */
 function add_meta_boxes() {
 	add_meta_box(

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -84,20 +84,22 @@ function get_stale_in_fields() {
 function display_staleness_management_meta_box( $post ) {
 	$stale_in = get_post_meta( $post->ID, '_sfs411_stale_in', true );
 	$stale_by = get_post_meta( $post->ID, '_sfs411_stale_by', true );
+	$flagged  = $stale_in && $stale_by;
 
 	wp_nonce_field( 'sfs411_check_staleness_nonce', 'sfs411-staleness-nonce' );
 
-	$flagged = $stale_in && $stale_by;
-
 	if ( $flagged ) :
+		$message = ( date( 'Y-m-d' ) > $stale_by )
+			? 'This post has been marked as stale since '
+			: 'This post is set to be marked as stale on ';
 		?>
-		<p id="sfs411-staleness-settings_message">This post is set to be marked as stale on <?php echo esc_html( date( 'F j, Y', strtotime( $stale_by ) ) ); ?>.</p>
+		<p id="sfs411-staleness-management_message"><?php echo esc_html( $message . date( 'F j, Y', strtotime( $stale_by ) ) ); ?>.</p>
 		<?php
 	endif;
 	?>
 
 	<div
-		id="sfs411-staleness-settings_duration-options"
+		id="sfs411-staleness-management_options"
 		<?php if ( $flagged ) : ?>class="hidden"<?php endif; ?>
 	>
 
@@ -107,23 +109,35 @@ function display_staleness_management_meta_box( $post ) {
 		<p>
 			<input
 				type="radio"
-				id="<?php echo esc_attr( $id ); ?>"
+				id="sfs411-staleness-management_options-<?php echo esc_attr( $id ); ?>"
 				name="_sfs411_stale_in"
 				value="<?php echo esc_attr( $value ); ?>"
 				<?php
 				checked( $stale_in, $value );
 				disabled( $flagged );
 				?>
-
 			>
-			<label for="<?php echo esc_attr( $id ); ?>">in <?php echo esc_html( $value ); ?></label>
+			<label for="sfs411-staleness-management_options-<?php echo esc_attr( $id ); ?>">in <?php echo esc_html( $value ); ?></label>
 		</p>
 		<?php endforeach; ?>
 
+		<?php if ( empty( get_current_screen()->action ) ) : ?>
+			<p><label for="sfs411-staleness-management_options-note">Leave a brief note explaining why this post is no longer stale (optional):</label></p>
+			<textarea
+				id="sfs411-staleness-management_options-note"
+				name="_sfs411_reset_note"
+				<?php disabled( $flagged ); ?>
+			></textarea>
+		<?php endif; ?>
+
 	</div>
 
-	<?php if ( $flagged ) : ?>
-		<button id="sfs411-staleness-settings_reset" class="components-button is-link">Reset</button>
+	<?php
+	if ( $flagged ) :
+		?>
+
+		<button id="sfs411-staleness-management_reset" class="components-button is-link">Reset</button>
+
 		<?php
 	endif;
 }

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -9,6 +9,8 @@ namespace SFS411\Dashboard\Stale_Content;
 
 add_action( 'admin_menu', __NAMESPACE__ . '\add_stale_posts_page' );
 add_filter( 'submenu_file', __NAMESPACE__ . '\stale_posts_submenu_file' );
+add_action( 'add_meta_boxes_knowledge_base', __NAMESPACE__ . '\\add_meta_boxes' );
+add_action( 'save_post_knowledge_base', __NAMESPACE__ . '\\save_post', 10, 2 );
 
 /**
  * Adds the Stale Posts page the the Knowledge Base menu.
@@ -37,4 +39,109 @@ function stale_posts_submenu_file( $submenu_file ) {
 	}
 
 	return $submenu_file;
+}
+
+/**
+ * Adds a meta box for managing post staleness.
+ *
+ * @since 0.3.0
+ *
+ * @param string $post_type
+ */
+function add_meta_boxes() {
+	add_meta_box(
+		'sfs411-staleness-management',
+		'Staleness Management',
+		__NAMESPACE__ . '\display_staleness_management_meta_box',
+		'knowledge_base',
+		'side',
+		'high'
+	);
+}
+
+/**
+ * Returns an array of field values keyed by id.
+ *
+ * @return array Field values keyed by id.
+ */
+function get_stale_in_fields() {
+	return array(
+		'half-year' => '6 months',
+		'year'      => '1 year',
+	);
+}
+
+/**
+ * Displays a meta box used to manage post staleness.
+ *
+ * @since 0.3.0
+ *
+ * @param \WP_Post $post
+ */
+function display_staleness_management_meta_box( $post ) {
+	$stale_in = get_post_meta( $post->ID, '_sfs411_stale_in', true );
+	$stale_by = get_post_meta( $post->ID, '_sfs411_stale_by', true );
+
+	wp_nonce_field( 'sfs411_check_staleness_nonce', 'sfs411-staleness-nonce' );
+
+	if ( $stale_in && $stale_by ) :
+		?>
+			<p>This post is set to be marked as stale on <?php echo esc_html( date( 'F j, Y', strtotime( $stale_by ) ) ); ?>.
+		<?php
+	endif;
+
+	?>
+
+	<p>Mark this post as stale:</p>
+
+	<?php foreach ( get_stale_in_fields() as $id => $value ) : ?>
+	<p>
+		<input
+			type="radio"
+			id="<?php echo esc_attr( $id ); ?>"
+			name="_sfs411_stale_in"
+			value="<?php echo esc_attr( $value ); ?>"
+			<?php checked( $stale_in, $value ); ?>
+		>
+		<label for="half-year">in <?php echo esc_html( $value ); ?></label>
+	</p>
+	<?php endforeach; ?>
+
+	<?php
+}
+
+/**
+ * Saves the meta for tracking the staleness of a post.
+ *
+ * @since 0.3.0
+ *
+ * @param int      $post_id
+ * @param \WP_Post $post
+ */
+function save_post( $post_id, $post ) {
+	if ( ! isset( $_POST['sfs411-staleness-nonce'] ) || ! wp_verify_nonce( $_POST['sfs411-staleness-nonce'], 'sfs411_check_staleness_nonce' ) ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		return;
+	}
+
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+
+	if ( 'auto-draft' === $post->post_status ) {
+		return;
+	}
+
+	if ( isset( $_POST['_sfs411_stale_in'] ) && in_array( $_POST['_sfs411_stale_in'], array_values( get_stale_in_fields() ), true ) ) {
+
+		// Get the current date and modify it by the `_sfs411_stale_in` value.
+		$date = new \DateTime();
+		$stale_by = $date->modify( '+' . $_POST['_sfs411_stale_in'] )->format( 'Y-m-d' );
+
+		update_post_meta( $post_id, '_sfs411_stale_by', $stale_by );
+		update_post_meta( $post_id, '_sfs411_stale_in', $_POST['_sfs411_stale_in'] );
+	}
 }

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -67,8 +67,9 @@ function add_meta_boxes() {
  */
 function get_stale_in_fields() {
 	return array(
-		'half-year' => '6 months',
-		'year'      => '1 year',
+		'quarterly'  => '3 months',
+		'biannually' => '6 months',
+		'annually'   => '1 year',
 	);
 }
 

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -113,7 +113,6 @@ function stale_post_views( $views ) {
 
 	// Replace the default count with the stale posts by the current user.
 	$views['mine'] = preg_replace(
-		//'/\([^)]+\)/',
 		'/\(\d+\)/',
 		'(' . $users_stale_posts_count . ')',
 		$views['mine']

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Handling for the Stale Posts dashboard.
+ *
+ * @package sfs411
+ */
+
+namespace SFS411\Dashboard\Stale_Content;
+
+add_action( 'admin_menu', __NAMESPACE__ . '\add_stale_posts_page' );
+add_filter( 'submenu_file', __NAMESPACE__ . '\stale_posts_submenu_file' );
+
+/**
+ * Adds the Stale Posts page the the Knowledge Base menu.
+ */
+function add_stale_posts_page() {
+	add_submenu_page(
+		'edit.php?post_type=knowledge_base',
+		'Stale Posts',
+		'Stale Posts',
+		'manage_options',
+		'edit.php?post_type=knowledge_base&stale',
+		'',
+		2
+	);
+}
+
+/**
+ * Filters the file of the Stale Posts menu item.
+ *
+ * @param string $submenu_file The submenu file.
+ * @return string The submenu file.
+ */
+function stale_posts_submenu_file( $submenu_file ) {
+	if ( 'edit-knowledge_base' === get_current_screen()->id && isset( $_GET['stale'] ) ) { // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+		$submenu_file = 'edit.php?post_type=knowledge_base&stale';
+	}
+
+	return $submenu_file;
+}

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -10,7 +10,7 @@ namespace SFS411\Dashboard\Stale_Content;
 add_action( 'admin_menu', __NAMESPACE__ . '\add_stale_posts_page' );
 add_filter( 'submenu_file', __NAMESPACE__ . '\stale_posts_submenu_file' );
 add_action( 'add_meta_boxes_knowledge_base', __NAMESPACE__ . '\add_meta_boxes' );
-add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_meta_box_script' );
+add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_meta_box_assets' );
 add_action( 'save_post_knowledge_base', __NAMESPACE__ . '\save_post', 10, 2 );
 add_filter( 'pre_get_posts', __NAMESPACE__ . '\filter_by_stale_posts' );
 
@@ -147,16 +147,25 @@ function display_staleness_management_meta_box( $post ) {
  *
  * @param string $hook_suffix The current admin page
  */
-function enqueue_meta_box_script( $hook_suffix ) {
-	if ( 'post.php' === $hook_suffix && 'knowledge_base' === get_current_screen()->id ) {
-		wp_enqueue_script(
-			'sfs411-stale-content',
-			get_stylesheet_directory_uri() . '/includes/js/stale-content-meta-box.js',
-			array(),
-			spine_get_child_version(),
-			true
-		);
+function enqueue_meta_box_assets( $hook_suffix ) {
+	if ( 'post.php' !== $hook_suffix || 'knowledge_base' !== get_current_screen()->id ) {
+		return;
 	}
+
+	wp_enqueue_script(
+		'sfs411-stale-content',
+		get_stylesheet_directory_uri() . '/includes/js/stale-content-meta-box.js',
+		array(),
+		spine_get_child_version(),
+		true
+	);
+
+	wp_enqueue_style(
+		'sfs411-stale-content',
+		get_stylesheet_directory_uri() . '/includes/css/stale-content-meta-box.css',
+		array(),
+		spine_get_child_version()
+	);
 }
 
 /**

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -22,7 +22,7 @@ function add_stale_posts_page() {
 		'edit.php?post_type=knowledge_base',
 		'Stale Posts',
 		'Stale Posts',
-		'manage_options',
+		'edit_posts',
 		'edit.php?post_type=knowledge_base&stale',
 		'',
 		2

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -184,15 +184,37 @@ function save_post( $post_id, $post ) {
 		return;
 	}
 
-	if ( isset( $_POST['_sfs411_stale_in'] ) && in_array( $_POST['_sfs411_stale_in'], array_values( get_stale_in_fields() ), true ) ) {
-
-		// Get the current date and modify it by the `_sfs411_stale_in` value.
-		$date = new \DateTime();
-		$stale_by = $date->modify( '+' . $_POST['_sfs411_stale_in'] )->format( 'Y-m-d' );
-
-		update_post_meta( $post_id, '_sfs411_stale_by', $stale_by );
-		update_post_meta( $post_id, '_sfs411_stale_in', $_POST['_sfs411_stale_in'] );
+	if ( ! isset( $_POST['_sfs411_stale_in'] ) || ! in_array( $_POST['_sfs411_stale_in'], array_values( get_stale_in_fields() ), true ) ) {
+		return;
 	}
+
+	update_post_meta( $post_id, '_sfs411_stale_in', $_POST['_sfs411_stale_in'] );
+
+	// Get the current date and modify it by the `_sfs411_stale_in` value.
+	$date = new \DateTime();
+	$stale_by = $date->modify( '+' . $_POST['_sfs411_stale_in'] )->format( 'Y-m-d' );
+
+	update_post_meta( $post_id, '_sfs411_stale_by', $stale_by );
+
+	// Get existing reset log meta.
+	$reset_log = get_post_meta( $post_id, '_sfs411_reset_log', true );
+	$reset_log = ( $reset_log ) ? $reset_log : array();
+
+	// Set up user and date of the current reset.
+	$this_reset = array(
+		'user' => wp_get_current_user()->user_login,
+		'date' => date( 'm-d-Y' ),
+	);
+
+	// Add the note for the current reset if there is one.
+	if ( isset( $_POST['_sfs411_reset_note'] ) ) {
+		$this_reset['note'] = sanitize_text_field( $_POST['_sfs411_reset_note'] );
+	}
+
+	// Append the current reset to the log.
+	$reset_log[] = $this_reset;
+
+	update_post_meta( $post_id, '_sfs411_reset_log', $reset_log );
 }
 
 /**

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -11,6 +11,7 @@ add_action( 'admin_menu', __NAMESPACE__ . '\add_stale_posts_page' );
 add_filter( 'submenu_file', __NAMESPACE__ . '\stale_posts_submenu_file' );
 add_filter( 'views_edit-knowledge_base', __NAMESPACE__ . '\stale_post_views' );
 add_filter( 'bulk_actions-edit-knowledge_base', __NAMESPACE__ . '\filter_bulk_actions' );
+add_filter( 'post_row_actions', __NAMESPACE__ . '\post_row_actions', 10, 2 );
 add_action( 'add_meta_boxes_knowledge_base', __NAMESPACE__ . '\add_meta_boxes' );
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_meta_box_assets' );
 add_action( 'save_post_knowledge_base', __NAMESPACE__ . '\save_post', 10, 2 );
@@ -129,6 +130,21 @@ function stale_post_views( $views ) {
  */
 function filter_bulk_actions( $actions ) {
 	if ( is_stale_posts_page() ) {
+		unset( $actions['trash'] );
+	}
+
+	return $actions;
+}
+
+/**
+ * Removes row actions that are not relevant to the Stale Posts dashboard.
+ *
+ * @param array   $actions Array of row action links.
+ * @param WP_Post $post    The post object.
+ */
+function post_row_actions( $actions, $post ) {
+	if ( 'knowledge_base' === $post->post_type && is_stale_posts_page() ) {
+		unset( $actions['inline hide-if-no-js'] );
 		unset( $actions['trash'] );
 	}
 


### PR DESCRIPTION
* Introduce a theme version for use in cache busting.
* Introduce a "Stale Posts" dashboard page that uses the Knowledge Base post list table.
* Modify the query for the "Stale Posts" dashboard page.
* Introduce a meta box for managing Knowledge Base post staleness.
  * Options to mark the post as stale in `3 months`, `6 months`, and `1 year`.
  * A message stating when the post is set to be marked as stale (or that it is already stale).
  * A `reset` button which:
    * resurfaces the duration options; and
    * surfaces a textarea for capturing a note about the reset.
  * The current date, modified by the selected duration, is saved as an additional piece of meta in the `Y-m-d` format, and is leveraged on the "Stale Posts" dashboard page.
  * Resets are stored under the `_sfs411_reset_log` meta key in the following format:
```
{
  { "user": "username", "date": "mm-dd-yyyy", "note": "note about the reset" },
  { "user": "username", "date": "mm-dd-yyyy", "note": "note about the reset" },
}
```
 (The reset log is _not_ currently output anywhere.)

This should be rebased against master after #3 is merged.