### PR TITLE
Add email notifications

### DIFF
--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -85,12 +85,7 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 		</div>
 	<?php endif; ?>
 
-	<?php
-	// Display the comments template if the current user is logged in.
-	//if ( is_user_logged_in() ) {
-		comments_template();
-	//}
-	?>
+	<?php comments_template(); ?>
 
 	<footer class="article-footer">
 

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -29,7 +29,7 @@ function register_html5_support() {
  * @return array $comment_fields A modified list of comment fields.
  */
 function filter_comment_form_fields( $comment_fields ) {
-	if ( 'knowledge_base' === get_post_type() ) {
+	if ( 'knowledge_base' === get_post_type() && is_user_logged_in() ) {
 
 		// Add a checkbox for flagging that the comment is about bad content on the post.
 		$flag_checkbox = '<p class="comment-form-flag"><input type="checkbox" id="content-flag" name="content_flag" /><label for="content-flag">This post has old, missing, or incorrect content</label></p>';

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -456,7 +456,7 @@ function comment_post( $comment_id, $comment_approved, $comment_data ) {
 
 	$subject = 'Your SFS 411 Knowledge Base post was flagged for content';
 
-	$dashboard_url   = add_query_arg( 'comment_type', 'flagged_content', get_admin_url( 'edit-comments.php' ) );
+	$dashboard_url   = add_query_arg( 'comment_type', 'flagged_content', get_admin_url( null, 'edit-comments.php' ) );
 	$flag_dashboard  = esc_url( add_query_arg( 'id', absint( $comment_id ), $dashboard_url ) );
 	$post_flags_dash = esc_url( add_query_arg( 'p', absint( $post->ID ), $dashboard_url ) );
 

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -12,6 +12,7 @@ add_filter( 'parent_file', __NAMESPACE__ . '\flagged_posts_parent_file' );
 add_filter( 'submenu_file', __NAMESPACE__ . '\flagged_posts_submenu_file' );
 add_action( 'adminmenu', __NAMESPACE__ . '\adminmenu' );
 add_filter( 'comment_row_actions', __NAMESPACE__ . '\comment_row_actions', 10, 2 );
+add_action( 'admin_head', __NAMESPACE__ . '\admin_head' );
 add_action( 'admin_footer', __NAMESPACE__ . '\admin_footer' );
 add_filter( 'preprocess_comment', __NAMESPACE__ . '\preprocess_comment_data' );
 add_action( 'pre_get_comments', __NAMESPACE__ . '\filter_comments_query' );
@@ -150,7 +151,26 @@ function comment_row_actions( $actions, $comment ) {
 }
 
 /**
- * Add a checkbox to the comment list table reply form for resolving flags.
+ * Hides the comment filters for the Flagged Posts page.
+ */
+function admin_head() {
+
+	// Return early if this is not the Flagged Posts page.
+	if ( ! is_flagged_posts_page() ) {
+		return;
+	}
+	?>
+	<style type="text/css">
+		#filter-by-comment-type,
+		#post-query-submit {
+			display: none;
+		}
+	</style>
+	<?php
+}
+
+/**
+ * Adds a checkbox to the comment list table reply form for resolving flags.
  */
 function admin_footer() {
 
@@ -424,7 +444,7 @@ function filter_bulk_actions( $actions ) {
 }
 
 /**
- * Disable default comment notifications for comments flagging bad content
+ * Disables default comment notifications for comments flagging bad content
  * or resolving bad content flags.
  *
  * @param bool $maybe_notify Whether to notify blog moderator/post author.
@@ -441,7 +461,7 @@ function disable_default_notification( $maybe_notify, $comment_id ) {
 }
 
 /**
- * Send an email when a comment flagging bad content is submitted.
+ * Sends an email when a comment flagging bad content is submitted.
  *
  * @param int        $comment_id       The comment ID.
  * @param int|string $comment_approved 1 if the comment is approved, 0 if not, 'spam' if spam.

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -439,7 +439,7 @@ function disable_default_notification( $maybe_notify, $comment_id ) {
 function comment_post( $comment_id, $comment_approved, $comment_data ) {
 
 	// Return early if the comment is not of the `flagged-content` type.
-	if ( 'flagged_content' !== $comment_data->comment_type ) {
+	if ( 'flagged_content' !== $comment_data['comment_type'] ) {
 		return;
 	}
 
@@ -448,7 +448,7 @@ function comment_post( $comment_id, $comment_approved, $comment_data ) {
 		return;
 	}
 
-	$post = get_post( $comment_data->comment_post_ID );
+	$post = get_post( $comment_data['comment_post_ID'] );
 
 	$author_id = $post->post_author;
 
@@ -461,9 +461,9 @@ function comment_post( $comment_id, $comment_approved, $comment_data ) {
 	$post_flags_dash = esc_url( add_query_arg( 'p', absint( $post->ID ), $dashboard_url ) );
 	$all_posts_flags = esc_url( add_query_arg( 'comment_status', 'my_posts', $dashboard_url ) );
 
-	$body  = '<p>The Knowledge Base post "' . get_the_title() . '" has been flagged for old, missing, or inaccurate content.</p>';
+	$body .= '<p>The Knowledge Base post "' . get_the_title( $post ) . '" has been flagged for old, missing, or inaccurate content.</p>';
 	$body .= '<p>Please review the concern at <a href="' . $flag_dashboard . '">' . $flag_dashboard . '</a>. It can be resolved by clicking the "Resolve" action beneath the comment.</p>';
-	$body .= '<p>View all flags on "' . get_the_title() . '" at <a href="' . $post_flags_dash . '">' . $post_flags_dash . '</a>.</p>';
+	$body .= '<p>View all flags on "' . get_the_title( $post ) . '" at <a href="' . $post_flags_dash . '">' . $post_flags_dash . '</a>.</p>';
 	$body .= '<p>View flags for all your posts at <a href="' . $all_posts_flags . '">' . $all_posts_flags . '</a>.</p>';
 
 	$headers = array( 'Content-Type: text/html; charset=UTF-8' );

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -160,6 +160,7 @@ function admin_footer() {
 	}
 	?>
 	<script type="text/javascript">
+		// Add a checkbox for marking a reply as a resolution of the content flag.
 		function addResolveCheckbox() {
 			const checkbox = document.createElement( 'input' );
 			const label = document.createElement( 'label' );
@@ -177,10 +178,20 @@ function admin_footer() {
 			replyContainer.appendChild( label );
 		};
 
+		// Remove the filter actions, except for the "Empty Trash" button.
 		function removeFilterActions() {
 			const filterActions = document.getElementById( 'filter-by-comment-type' ).parentNode;
 
-			filterActions.parentNode.removeChild( filterActions );
+			let child = filterActions.firstElementChild;
+
+			while ( child ) {
+				if ( 'delete_all' === child.id ) {
+					break;
+				}
+
+				filterActions.removeChild( child );
+				child = filterActions.firstElementChild;
+			}
 		}
 
 		addResolveCheckbox();

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -459,10 +459,12 @@ function comment_post( $comment_id, $comment_approved, $comment_data ) {
 	$dashboard_url   = add_query_arg( 'comment_type', 'flagged_content', get_admin_url( null, 'edit-comments.php' ) );
 	$flag_dashboard  = esc_url( add_query_arg( 'id', absint( $comment_id ), $dashboard_url ) );
 	$post_flags_dash = esc_url( add_query_arg( 'p', absint( $post->ID ), $dashboard_url ) );
+	$all_posts_flags = esc_url( add_query_arg( 'comment_status', 'my_posts', $dashboard_url ) );
 
 	$body  = '<p>The Knowledge Base post "' . get_the_title() . '" has been flagged for old, missing, or inaccurate content.</p>';
 	$body .= '<p>Please review the concern at <a href="' . $flag_dashboard . '">' . $flag_dashboard . '</a>. It can be resolved by clicking the "Resolve" action beneath the comment.</p>';
-	$body .= '<p>View all flags on "' . get_the_title() . '": <a href="' . $post_flags_dash . '">' . $post_flags_dash . '</a>';
+	$body .= '<p>View all flags on "' . get_the_title() . '" at <a href="' . $post_flags_dash . '">' . $post_flags_dash . '</a>.</p>';
+	$body .= '<p>View flags for all your posts at <a href="' . $all_posts_flags . '">' . $all_posts_flags . '</a>.</p>';
 
 	$headers = array( 'Content-Type: text/html; charset=UTF-8' );
 

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -395,7 +395,7 @@ function send_email() {
 				'post_type' => 'knowledge_base',
 				'stale'     => true,
 				'author'    => get_current_user_id(),
-			), get_admin_url( 'edit.php' ) ) );
+			), get_admin_url( null, 'edit.php' ) ) );
 
 			$body  = '<p>The Knowledge Base post "' . get_the_title() . '" has been scheduled for review.</p>';
 			$body .= '<p>Please make any necessary changes at <a href="' . $edit_post . '">' . $edit_post . '</a>, then use the "Reset" button in the "Staleness Management" box to schedule the next time the post should be reviewed.<p>';


### PR DESCRIPTION
* Introduce a cron job that checks for stale posts once a day.
   * If stale posts are found, the author is notified via email.
* Disable default email notifications for comments of the `flagged_content` and `resolved` type.
* Email the post author when a comment flagging bad content is left on their post.
* Fixes the counts for the "Comments" and "Flagged Posts" dashboard status links.
* Adds the checkbox for flagging bad content to the comment form only for logged in users.

This should be rebased against master after #4 is merged.